### PR TITLE
set db dir under PHOLD_DBDIR environement variable control

### DIFF
--- a/src/phold/utils/constants.py
+++ b/src/phold/utils/constants.py
@@ -1,9 +1,9 @@
 from pathlib import Path
-
+import os
 repo_root = Path(__file__).parent.parent.resolve()
 
 CNN_DIR = repo_root / "cnn/"
 
-DB_DIR = repo_root / "database/"
+DB_DIR = os.environ.get("PHOLD_DBDIR", repo_root / "database/")
 
 FINETUNE_DIR = repo_root / "finetune/"


### PR DESCRIPTION
Hello, 

suggestion to have phold database directory under possible control via PHOLD_DBDIR environment variable.
this allow to separate the phold installation from large database directory (> 7G) 

NB context 
1) we package our tools using  .rpm//.deb packages this will allow me to reduce the package footprint)
2) will allow  to update phold databases (if needed) whithout ingterfering with the packages.

regards

Eric 