### PR TITLE
Add .tbl NCBI feature table output for GenBank submission

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -5,6 +5,7 @@
 * `_aa.fasta` which will hold all amino acid sequences of predicted CDSs
 * `_3di.fasta` which will hold all Foldseek 3Di sequences of predicted CDSs as predicted by ProstT5
 * `_.gbk` which will contain a Genbank format file of your phage(s) with all annotations
+* `.tbl` which contains an [NCBI feature table](https://www.ncbi.nlm.nih.gov/genbank/feature_table/) of all annotations, for ease of submission to GenBank with [table2asn](https://www.ncbi.nlm.nih.gov/genbank/table2asn/). This includes all CDS, along with any tRNA, tmRNA and CRISPR repeat features carried over from your Pharokka input. It is not created for `phold proteins-predict` or `phold proteins-compare`, as protein input has no contig coordinates
 * `_all_cds_functions.tsv` which includes for each contig:
     * Total CDS counts
     * Total CDS counts of each PHROG category 

--- a/docs/output.md
+++ b/docs/output.md
@@ -5,7 +5,7 @@
 * `_aa.fasta` which will hold all amino acid sequences of predicted CDSs
 * `_3di.fasta` which will hold all Foldseek 3Di sequences of predicted CDSs as predicted by ProstT5
 * `_.gbk` which will contain a Genbank format file of your phage(s) with all annotations
-* `.tbl` which contains an [NCBI feature table](https://www.ncbi.nlm.nih.gov/genbank/feature_table/) of all annotations, for ease of submission to GenBank with [table2asn](https://www.ncbi.nlm.nih.gov/genbank/table2asn/). This includes all CDS, along with any tRNA, tmRNA and CRISPR repeat features carried over from your Pharokka input. It is not created for `phold proteins-predict` or `phold proteins-compare`, as protein input has no contig coordinates
+* `.tbl` which contains an [NCBI feature table](https://www.ncbi.nlm.nih.gov/genbank/feature_table/) of all annotations, for ease of submission to GenBank with [table2asn](https://www.ncbi.nlm.nih.gov/genbank/table2asn/). This includes all CDS, along with any tRNA, tmRNA and CRISPR repeat features carried over from your Pharokka input. CDS that run off the edge of a contig are marked as incomplete with `<` and `>`, and get a `codon_start` where the reading frame requires it. It is not created for `phold proteins-predict` or `phold proteins-compare`, as protein input has no contig coordinates
 * `_all_cds_functions.tsv` which includes for each contig:
     * Total CDS counts
     * Total CDS counts of each PHROG category 

--- a/docs/output.md
+++ b/docs/output.md
@@ -5,7 +5,9 @@
 * `_aa.fasta` which will hold all amino acid sequences of predicted CDSs
 * `_3di.fasta` which will hold all Foldseek 3Di sequences of predicted CDSs as predicted by ProstT5
 * `_.gbk` which will contain a Genbank format file of your phage(s) with all annotations
-* `.tbl` which contains an [NCBI feature table](https://www.ncbi.nlm.nih.gov/genbank/feature_table/) of all annotations, for ease of submission to GenBank with [table2asn](https://www.ncbi.nlm.nih.gov/genbank/table2asn/). This includes all CDS, along with any tRNA, tmRNA and CRISPR repeat features carried over from your Pharokka input. CDS that run off the edge of a contig are marked as incomplete with `<` and `>`, and get a `codon_start` where the reading frame requires it. It is not created for `phold proteins-predict` or `phold proteins-compare`, as protein input has no contig coordinates
+* `.tbl` which contains an [NCBI feature table](https://www.ncbi.nlm.nih.gov/genbank/feature_table/) of all annotations, for ease of submission to GenBank with [table2asn](https://www.ncbi.nlm.nih.gov/genbank/table2asn/). This includes all CDS, along with any tRNA, tmRNA and CRISPR repeat features carried over from your Pharokka input. CDS that run off the edge of a contig are marked as incomplete with `<` and `>`, and get a `codon_start` where the reading frame requires it. The `inference` qualifier cites the matching PHROG in NCBI's controlled format (`protein motif:PHROG:<phrog>`). It is not created for `phold proteins-predict` or `phold proteins-compare`, as protein input has no contig coordinates
+
+The `.tbl` has been checked against `table2asn` 1.28.1179, and produces no feature or qualifier errors. Note that `table2asn` will still ask you for the submission metadata it always needs — an organism (`-j "[organism=...]"`) and a submission template (`-t template.sbt`)
 * `_all_cds_functions.tsv` which includes for each contig:
     * Total CDS counts
     * Total CDS counts of each PHROG category 

--- a/src/phold/io/handle_genbank.py
+++ b/src/phold/io/handle_genbank.py
@@ -301,6 +301,13 @@ def get_fasta_run_pyrodigal_gv(input: Path, threads: int) -> dict:
                     f"Pyrodigal-gv_{pyrodigal_gv.__version__}"
                 )
                 feature.qualifiers["transl_table"] = gene.translation_table
+                # Prodigal-style partial flag, "<left><right>" in genomic
+                # orientation. Pharokka records the same qualifier on its
+                # GenBank CDS, so both input routes reach the .tbl writer
+                # (issue #137) with the same representation.
+                feature.qualifiers["partial"] = (
+                    f"{int(gene.partial_begin)}{int(gene.partial_end)}"
+                )
                 # from the API
                 # translation_table (int, optional) – An alternative translation table to use to translate the gene.
                 # Use None (the default) to translate using the translation table this gene was found with.
@@ -432,6 +439,16 @@ def write_genbank(
                             # for older pharokka input before v1.5.0
                             transl_table = "11"
 
+                    # Prodigal partial flag ("10"/"01"/"11"/"00"), needed by the
+                    # .tbl writer to mark incomplete CDS ends for GenBank
+                    # (issue #137). Same list-vs-bare-string split as
+                    # transl_table above. Absent for older Pharokka input and
+                    # for NCBI/Bakta GenBanks, which is fine — None simply
+                    # means "treat every end as complete".
+                    partial = cds_feature.qualifiers.get("partial")
+                    if isinstance(partial, (list, tuple)):
+                        partial = partial[0] if partial else None
+
                     # to reverse the start and end coordinates for output tsv + fix genbank 0 index start relative to pharokka
                     # turns out the genbank format adds 1 to the start coordinate on writing out issue #75 and #77
                     # e.g. [SeqFeature(SimpleLocation(ExactPosition(0), ExactPosition(1056), strand=1) - will be writted as start=1 and end=1056
@@ -476,6 +493,7 @@ def write_genbank(
                         "product": cds_feature.qualifiers["product"][0],
                         "annotation_method": source_dict[record_id][cds_id],
                         "transl_table": transl_table,
+                        "partial": partial,
                     }
 
                     # Remove unwanted gbk attributes if they exist
@@ -580,6 +598,13 @@ def write_genbank(
     per_cds_df = pl.DataFrame(per_cds_list)
 
     if proteins_flag is False:
+        # ``partial`` is absent on older Pharokka / NCBI / Bakta input, so the
+        # column can infer as Null (all missing) or trip inference on a mixed
+        # None/str run. Pin it to Utf8 so the .tbl writer always sees either a
+        # string or None.
+        if "partial" in per_cds_df.columns:
+            per_cds_df = per_cds_df.with_columns(pl.col("partial").cast(pl.Utf8))
+
         # Convert strand: -1 → "-", +1 → "+", anything else → string repr.
         # Vectorised pl.when() chain replaces the original row-wise
         # .apply(lambda) call.

--- a/src/phold/io/tbl.py
+++ b/src/phold/io/tbl.py
@@ -1,0 +1,223 @@
+"""
+NCBI feature-table (``.tbl``) writer — GenBank submission output.
+
+Mirrors the ``.tbl`` that Pharokka emits (``pharokka.post_processing.create_tbl``)
+so a Phold-reannotated genome can be handed to ``table2asn`` for GenBank
+submission without a format conversion step (issue #137).
+
+Format (tab-separated, per the NCBI feature-table spec):
+
+    >Feature <contig_id>
+    <start>\t<stop>\t<feature_key>
+    \t\t\t<qualifier>\t<value>
+
+``start``/``stop`` are 1-based and inclusive, and are written in *transcription*
+order: for a minus-strand feature the larger coordinate comes first. That
+ordering is how the feature table encodes strand — there is no separate strand
+column — so it is the one piece of the format that must not be "tidied".
+"""
+
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import polars as pl
+from loguru import logger
+
+from Bio.SeqFeature import SeqFeature
+
+from phold.utils.util import atomic_write_path
+
+
+# Qualifiers emitted for a CDS, in the order NCBI's examples use. Values come
+# from per_cds_df, which write_genbank() has already normalised to 1-based
+# inclusive coordinates (see the issue #75/#77 comment there).
+_CDS_QUALIFIER_COLUMNS: Tuple[Tuple[str, str], ...] = (
+    ("product", "product"),
+    ("function", "function"),
+    ("annotation_method", "inference"),
+    ("transl_table", "transl_table"),
+)
+
+# Phold/Pharokka bookkeeping qualifiers that must never reach a submission
+# file: either they are internal identifiers, or table2asn rejects them.
+# ``ID``/``locus_tag`` are dropped because NCBI assigns locus tags at
+# submission time; ``score``/``source``/``phase`` are pipeline provenance.
+_NON_CDS_QUALIFIER_BLOCKLIST = frozenset(
+    {
+        "ID",
+        "locus_tag",
+        "score",
+        "source",
+        "phase",
+        "translation",
+        "transl_table",
+        "phrog",
+        "top_hit",
+        "isotype",
+    }
+)
+
+# Pharokka writes the tRNA name to a ``/trna`` qualifier, which is not a valid
+# NCBI qualifier — ``product`` is, and it is mandatory for the tRNA feature key.
+# ``write_genbank`` renames it in place, but only for records it walks, so do
+# the same mapping here rather than depending on that call having happened
+# first: a tRNA reaching table2asn without a product is rejected.
+_QUALIFIER_ALIASES: Tuple[Tuple[str, str], ...] = (("trna", "product"),)
+
+# Preferred emission order for the non-CDS qualifiers Pharokka carries. Anything
+# not listed keeps dict order after these.
+_NON_CDS_QUALIFIER_ORDER: Tuple[str, ...] = (
+    "gene",
+    "product",
+    "inference",
+    "ncRNA_class",
+    "anticodon",
+    "tag_peptide",
+    "rpt_family",
+    "rpt_type",
+    "rpt_unit_range",
+    "rpt_unit_seq",
+    "db_xref",
+    "note",
+)
+
+
+def _orient(start: int, end: int, strand: Optional[int]) -> Tuple[int, int]:
+    """Return (start, stop) in transcription order.
+
+    A minus-strand feature is written high-coordinate first; that swap *is*
+    the strand annotation in a feature table.
+    """
+    if strand is not None and int(strand) == -1:
+        return end, start
+    return start, end
+
+
+def _write_cds_features(handle, contig_df: pl.DataFrame) -> int:
+    """Write every CDS row of one contig. Returns the number written."""
+    written = 0
+    for row in contig_df.iter_rows(named=True):
+        start, stop = _orient(int(row["start"]), int(row["end"]), row.get("strand"))
+        handle.write(f"{start}\t{stop}\tCDS\n")
+
+        for column, qualifier in _CDS_QUALIFIER_COLUMNS:
+            value = row.get(column)
+            # A null product/function would emit a bare qualifier line that
+            # table2asn treats as a parse error, so skip rather than write "".
+            if value is None or str(value).strip() == "":
+                continue
+            handle.write(f"\t\t\t{qualifier}\t{value}\n")
+        written += 1
+    return written
+
+
+def _non_cds_sort_key(item: Tuple[str, SeqFeature]) -> int:
+    """Sort non-CDS features by start coordinate, tolerating odd locations."""
+    _, feature = item
+    try:
+        return int(feature.location.start)
+    except (AttributeError, TypeError):
+        return 0
+
+
+def _write_non_cds_features(
+    handle, features: Dict[str, SeqFeature]
+) -> int:
+    """Write tRNA / tmRNA / CRISPR / ncRNA features carried over from the input.
+
+    Phold does not predict these — they are passed through from the Pharokka
+    (or NCBI/Bakta) input GenBank — but a submission-ready feature table has to
+    carry them, otherwise the .tbl silently describes fewer features than the
+    .gbk Phold wrote alongside it.
+    """
+    written = 0
+    for _, feature in sorted(features.items(), key=_non_cds_sort_key):
+        location = getattr(feature, "location", None)
+        if location is None:
+            continue
+
+        # BioPython locations are 0-based half-open; the feature table is
+        # 1-based inclusive, so the start needs +1 and the end is already
+        # the inclusive last base.
+        try:
+            start = int(location.start) + 1
+            end = int(location.end)
+        except (TypeError, ValueError):
+            logger.warning(
+                f"Skipping feature with an unparseable location in the .tbl: {feature.type}"
+            )
+            continue
+
+        start, stop = _orient(start, end, location.strand)
+        handle.write(f"{start}\t{stop}\t{feature.type}\n")
+
+        # Copy: the same SeqFeature objects are shared with the GenBank writer,
+        # so the alias rewrite below must not mutate the caller's features.
+        qualifiers = dict(feature.qualifiers or {})
+        for source_key, target_key in _QUALIFIER_ALIASES:
+            aliased = qualifiers.pop(source_key, None)
+            if aliased is not None and target_key not in qualifiers:
+                qualifiers[target_key] = aliased
+
+        ordered = [k for k in _NON_CDS_QUALIFIER_ORDER if k in qualifiers]
+        ordered += [k for k in qualifiers if k not in _NON_CDS_QUALIFIER_ORDER]
+
+        for key in ordered:
+            if key in _NON_CDS_QUALIFIER_BLOCKLIST:
+                continue
+            value = qualifiers[key]
+            # BioPython stores qualifiers as lists when parsed from a GenBank
+            # file but as bare strings when Phold built the feature itself.
+            if isinstance(value, (list, tuple)):
+                value = value[0] if value else None
+            if value is None or str(value).strip() == "":
+                continue
+            handle.write(f"\t\t\t{key}\t{value}\n")
+        written += 1
+    return written
+
+
+def write_tbl(
+    per_cds_df: pl.DataFrame,
+    non_cds_dict: Dict[str, Dict[str, SeqFeature]],
+    contig_ids: List[str],
+    prefix: str,
+    output: Path,
+) -> Path:
+    """Write the NCBI feature table for every contig.
+
+    Args:
+        per_cds_df: The per-CDS dataframe returned by ``write_genbank`` —
+            already 1-based inclusive, with contig_id / start / end / strand /
+            product / function / annotation_method / transl_table.
+        non_cds_dict: ``{contig_id: {feature_id: SeqFeature}}`` for the
+            tRNA / tmRNA / CRISPR features passed through from the input.
+        contig_ids: Contig order to emit, so the .tbl matches the .gbk.
+        prefix: Output filename prefix.
+        output: Output directory.
+
+    Returns:
+        Path to the written .tbl.
+
+    Note:
+        Every contig gets a ``>Feature`` header even when it has no features,
+        because table2asn matches records by that header — omitting an empty
+        contig makes it look absent from the submission rather than empty.
+    """
+    out_path: Path = Path(output) / f"{prefix}.tbl"
+
+    has_cds = per_cds_df.height > 0 and "contig_id" in per_cds_df.columns
+    total = 0
+
+    with atomic_write_path(out_path) as tmp, open(tmp, "w") as f:
+        for contig_id in contig_ids:
+            f.write(f">Feature {contig_id}\n")
+
+            if has_cds:
+                contig_df = per_cds_df.filter(pl.col("contig_id") == contig_id)
+                total += _write_cds_features(f, contig_df)
+
+            total += _write_non_cds_features(f, non_cds_dict.get(contig_id, {}))
+
+    logger.info(f"Wrote {total} features across {len(contig_ids)} contig(s) to {out_path}")
+    return out_path

--- a/src/phold/io/tbl.py
+++ b/src/phold/io/tbl.py
@@ -18,7 +18,7 @@ column — so it is the one piece of the format that must not be "tidied".
 """
 
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 import polars as pl
 from loguru import logger
@@ -82,23 +82,134 @@ _NON_CDS_QUALIFIER_ORDER: Tuple[str, ...] = (
 )
 
 
-def _orient(start: int, end: int, strand: Optional[int]) -> Tuple[int, int]:
+def _is_minus(strand: Optional[Union[int, str]]) -> bool:
+    """True for a minus-strand feature.
+
+    Strand reaches this module in two representations: ``per_cds_df`` has
+    already been converted to "+"/"-" strings by ``write_genbank``, while the
+    non-CDS ``SeqFeature`` objects still carry BioPython's ±1 ints. Accept
+    both — reading one as the other silently mis-orients every reverse-strand
+    feature in the file.
+    """
+    if strand is None:
+        return False
+    if isinstance(strand, str):
+        return strand.strip() in {"-", "-1"}
+    try:
+        return int(strand) == -1
+    except (TypeError, ValueError):
+        return False
+
+
+def _orient(
+    start: int, end: int, strand: Optional[Union[int, str]]
+) -> Tuple[int, int]:
     """Return (start, stop) in transcription order.
 
     A minus-strand feature is written high-coordinate first; that swap *is*
     the strand annotation in a feature table.
     """
-    if strand is not None and int(strand) == -1:
+    if _is_minus(strand):
         return end, start
     return start, end
 
 
-def _write_cds_features(handle, contig_df: pl.DataFrame) -> int:
+def _split_partial(
+    partial: Optional[str], strand: Optional[Union[int, str]]
+) -> Tuple[bool, bool]:
+    """Map a Prodigal ``partial`` flag onto (5'-incomplete, 3'-incomplete).
+
+    ``partial`` is two digits in *genomic* orientation — left edge then right
+    edge — regardless of strand (verified against pyrodigal's own GFF writer:
+    reverse-complementing a sequence turns a left-edge ``10`` gene into a
+    right-edge ``01`` gene). So the 5' end is the left digit on the plus
+    strand and the right digit on the minus strand.
+    """
+    if partial is None:
+        return False, False
+
+    text = str(partial).strip()
+    if len(text) != 2 or set(text) - {"0", "1"}:
+        return False, False
+
+    left, right = text[0] == "1", text[1] == "1"
+    if _is_minus(strand):
+        return right, left
+    return left, right
+
+
+def _cds_coordinates(
+    five_end: int,
+    three_end: int,
+    strand: Optional[Union[int, str]],
+    partial: Optional[str],
+    contig_length: Optional[int],
+) -> Tuple[str, str, Optional[int]]:
+    """Render a CDS's coordinate pair, with partial markers and codon_start.
+
+    ``five_end``/``three_end`` are taken straight from ``per_cds_df``, which is
+    **already in transcription order**: ``write_genbank`` assigns
+    ``start = location.end`` for a minus-strand CDS, so start > end there. They
+    must not be re-oriented — doing so writes every reverse-strand CDS
+    backwards. (The non-CDS path is different: those come from BioPython
+    locations, which really are genomic min/max, hence ``_orient``.)
+
+    NCBI marks an incomplete 5' end with ``<`` on the first coordinate and an
+    incomplete 3' end with ``>`` on the second. When the 5' end is incomplete
+    but does not sit flush against the contig edge, the feature is extended to
+    the edge and ``codon_start`` carries the reading-frame offset.
+
+    Returns ``(start_text, stop_text, codon_start)``.
+    """
+    five_partial, three_partial = _split_partial(partial, strand)
+    start_text, stop_text = str(five_end), str(three_end)
+    codon_start: Optional[int] = None
+
+    if three_partial:
+        stop_text = f">{three_end}"
+
+    if five_partial:
+        start_text = f"<{five_end}"
+
+        # Distance between the 5' end and the contig edge it ran off. Anything
+        # non-zero means the annotation must be pushed out to the edge, with
+        # the leftover bases declared as the frame offset. The minus-strand 5'
+        # end is the high coordinate, so it runs off the far end of the contig.
+        if _is_minus(strand):
+            if contig_length is not None and contig_length - five_end > 0:
+                codon_start = contig_length - five_end + 1
+                start_text = f"<{contig_length}"
+        elif five_end > 1:
+            codon_start = five_end
+            start_text = "<1"
+
+        # codon_start is a frame offset, so only 1/2/3 are meaningful. Warn
+        # rather than abort: this runs at the very end of a long pipeline, and
+        # a warning the user can act on beats losing the whole run's output.
+        if codon_start is not None and codon_start > 3:
+            logger.warning(
+                f"codon_start of {codon_start} for the partial CDS at "
+                f"{five_end}..{three_end} is greater than 3, which NCBI will "
+                "reject. Please raise an issue on GitHub with your genome."
+            )
+
+    return start_text, stop_text, codon_start
+
+
+def _write_cds_features(
+    handle, contig_df: pl.DataFrame, contig_length: Optional[int]
+) -> int:
     """Write every CDS row of one contig. Returns the number written."""
     written = 0
     for row in contig_df.iter_rows(named=True):
-        start, stop = _orient(int(row["start"]), int(row["end"]), row.get("strand"))
-        handle.write(f"{start}\t{stop}\tCDS\n")
+        start_text, stop_text, codon_start = _cds_coordinates(
+            int(row["start"]),
+            int(row["end"]),
+            row.get("strand"),
+            row.get("partial"),
+            contig_length,
+        )
+        handle.write(f"{start_text}\t{stop_text}\tCDS\n")
 
         for column, qualifier in _CDS_QUALIFIER_COLUMNS:
             value = row.get(column)
@@ -107,6 +218,10 @@ def _write_cds_features(handle, contig_df: pl.DataFrame) -> int:
             if value is None or str(value).strip() == "":
                 continue
             handle.write(f"\t\t\t{qualifier}\t{value}\n")
+
+        # After transl_table, matching Pharokka's field order.
+        if codon_start is not None:
+            handle.write(f"\t\t\tcodon_start\t{codon_start}\n")
         written += 1
     return written
 
@@ -183,18 +298,23 @@ def write_tbl(
     contig_ids: List[str],
     prefix: str,
     output: Path,
+    contig_lengths: Optional[Dict[str, int]] = None,
 ) -> Path:
     """Write the NCBI feature table for every contig.
 
     Args:
         per_cds_df: The per-CDS dataframe returned by ``write_genbank`` —
             already 1-based inclusive, with contig_id / start / end / strand /
-            product / function / annotation_method / transl_table.
+            product / function / annotation_method / transl_table, and
+            ``partial`` when the input carried Prodigal partial flags.
         non_cds_dict: ``{contig_id: {feature_id: SeqFeature}}`` for the
             tRNA / tmRNA / CRISPR features passed through from the input.
         contig_ids: Contig order to emit, so the .tbl matches the .gbk.
         prefix: Output filename prefix.
         output: Output directory.
+        contig_lengths: ``{contig_id: length}``, needed to place a minus-strand
+            5'-partial CDS against the contig edge. Without it those CDS still
+            get their ``<`` marker, just no codon_start.
 
     Returns:
         Path to the written .tbl.
@@ -215,7 +335,9 @@ def write_tbl(
 
             if has_cds:
                 contig_df = per_cds_df.filter(pl.col("contig_id") == contig_id)
-                total += _write_cds_features(f, contig_df)
+                total += _write_cds_features(
+                    f, contig_df, (contig_lengths or {}).get(contig_id)
+                )
 
             total += _write_non_cds_features(f, non_cds_dict.get(contig_id, {}))
 

--- a/src/phold/io/tbl.py
+++ b/src/phold/io/tbl.py
@@ -17,6 +17,7 @@ ordering is how the feature table encodes strand — there is no separate strand
 column — so it is the one piece of the format that must not be "tidied".
 """
 
+import re
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -28,15 +29,39 @@ from Bio.SeqFeature import SeqFeature
 from phold.utils.util import atomic_write_path
 
 
-# Qualifiers emitted for a CDS, in the order NCBI's examples use. Values come
-# from per_cds_df, which write_genbank() has already normalised to 1-based
-# inclusive coordinates (see the issue #75/#77 comment there).
+# Qualifiers emitted verbatim for a CDS, in the order NCBI's examples use.
+# Values come from per_cds_df, which write_genbank() has already normalised to
+# 1-based inclusive coordinates (see the issue #75/#77 comment there).
+# ``inference`` is not here — it has to be built (see _format_inference).
 _CDS_QUALIFIER_COLUMNS: Tuple[Tuple[str, str], ...] = (
     ("product", "product"),
     ("function", "function"),
-    ("annotation_method", "inference"),
-    ("transl_table", "transl_table"),
 )
+
+# INSDC requires /inference to begin with a category from a controlled
+# vocabulary, followed by ":<database>:<accession>". Phold's raw
+# annotation_method values ("foldseek", "pharokka", "none") have no category,
+# so table2asn rejects every one of them outright with "Qualifier had bad
+# value" — one hard error per CDS.
+#
+# Category choice, measured against table2asn 1.28.1179:
+#
+#   similar to AA sequence              -> InvalidInferenceValue warning
+#   similar to AA sequence:PHROG:1215   -> InvalidInferenceValue warning
+#                                          ("unrecognized database")
+#   protein motif:PHROG:1215            -> clean
+#   alignment:Foldseek:1215             -> clean
+#
+# The "similar to ... sequence" categories are checked against NCBI's list of
+# recognised databases, which PHROG is not on. "protein motif" is not, and is
+# also the honest description: a PHROG is a protein group / profile, and Phold
+# transfers its annotation from the group its structure matched.
+_INFERENCE_CATEGORY = "protein motif:PHROG"
+
+# annotation_method values that mean "no annotation was transferred", for
+# which no evidence can honestly be cited.
+_NO_INFERENCE_METHODS = frozenset({"none", "", "no_phrog"})
+
 
 # Phold/Pharokka bookkeeping qualifiers that must never reach a submission
 # file: either they are internal identifiers, or table2asn rejects them.
@@ -64,6 +89,12 @@ _NON_CDS_QUALIFIER_BLOCKLIST = frozenset(
 # first: a tRNA reaching table2asn without a product is rejected.
 _QUALIFIER_ALIASES: Tuple[Tuple[str, str], ...] = (("trna", "product"),)
 
+# NCBI's /anticodon must be a location, e.g. "(pos:115194..115196,aa:Met)".
+# Pharokka < v1.8.2 wrote a bare 3-letter code ("CAT"), which table2asn
+# rejects with "Qualifier had bad value" — write_genbank already warns about
+# that input, so drop the qualifier here rather than emit a known-invalid one.
+_ANTICODON_LOCATION = re.compile(r"^\(.*pos:.*\)$", re.IGNORECASE)
+
 # Preferred emission order for the non-CDS qualifiers Pharokka carries. Anything
 # not listed keeps dict order after these.
 _NON_CDS_QUALIFIER_ORDER: Tuple[str, ...] = (
@@ -80,6 +111,27 @@ _NON_CDS_QUALIFIER_ORDER: Tuple[str, ...] = (
     "db_xref",
     "note",
 )
+
+
+def _format_inference(method: Optional[str], phrog: Optional[str]) -> Optional[str]:
+    """Build a valid /inference string, or None to omit the qualifier.
+
+    Cites the PHROG the annotation came from. Without one there is no evidence
+    to point at, and a bare category is itself flagged by table2asn, so the
+    qualifier is omitted rather than padded with something invented.
+    """
+    if method is None or str(method).strip().lower() in _NO_INFERENCE_METHODS:
+        return None
+
+    if phrog is None:
+        return None
+
+    # "No_PHROG" is Phold's sentinel for a CDS with no PHROG assignment.
+    text = str(phrog).strip()
+    if not text or text.lower() == "no_phrog":
+        return None
+
+    return f"{_INFERENCE_CATEGORY}:{text}"
 
 
 def _is_minus(strand: Optional[Union[int, str]]) -> bool:
@@ -166,6 +218,13 @@ def _cds_coordinates(
     codon_start: Optional[int] = None
 
     if three_partial:
+        # NCBI expects a 3'-partial feature to run to the sequence edge. Gene
+        # callers stop at the last whole codon, leaving 1-2 trailing bases, and
+        # table2asn then warns "3' partial is not at end of sequence". Extend
+        # to the edge, mirroring the 5' handling below.
+        edge = 1 if _is_minus(strand) else contig_length
+        if edge is not None:
+            three_end = edge
         stop_text = f">{three_end}"
 
     if five_partial:
@@ -218,6 +277,14 @@ def _write_cds_features(
             if value is None or str(value).strip() == "":
                 continue
             handle.write(f"\t\t\t{qualifier}\t{value}\n")
+
+        inference = _format_inference(row.get("annotation_method"), row.get("phrog"))
+        if inference is not None:
+            handle.write(f"\t\t\tinference\t{inference}\n")
+
+        transl_table = row.get("transl_table")
+        if transl_table is not None and str(transl_table).strip() != "":
+            handle.write(f"\t\t\ttransl_table\t{transl_table}\n")
 
         # After transl_table, matching Pharokka's field order.
         if codon_start is not None:
@@ -286,6 +353,12 @@ def _write_non_cds_features(
             if isinstance(value, (list, tuple)):
                 value = value[0] if value else None
             if value is None or str(value).strip() == "":
+                continue
+            if key == "anticodon" and not _ANTICODON_LOCATION.match(str(value).strip()):
+                logger.warning(
+                    f"Dropping non-location anticodon '{value}' from the .tbl — "
+                    "re-run Pharokka >= v1.8.2 to submit this tRNA to GenBank."
+                )
                 continue
             handle.write(f"\t\t\t{key}\t{value}\n")
         written += 1

--- a/src/phold/subcommands/compare.py
+++ b/src/phold/subcommands/compare.py
@@ -15,6 +15,7 @@ from phold.features.create_foldseek_db import (
 from phold.features.run_foldseek import create_result_tsv, run_foldseek_search
 from phold.io.handle_genbank import write_genbank
 from phold.io.sub_db_outputs import create_sub_db_outputs
+from phold.io.tbl import write_tbl
 from phold.results.topfunction import (calculate_topfunctions_results,
                                        get_topcustom_hits,
                                        calculate_qcov_tcov,
@@ -804,5 +805,18 @@ def subcommand_compare(
     if not proteins_flag:
         descriptions_total_path: Path = Path(output) / f"{prefix}_all_cds_functions.tsv"
         _write_function_counts_table(merged_df, descriptions_total_path)
+
+        # NCBI feature table for GenBank submission (issue #137). Skipped for
+        # proteins input, which has no contig coordinates to describe.
+        # per_cds_df (not merged_df) is the source: write_genbank() already
+        # normalised its coordinates, and merged_df's left-joins can introduce
+        # null-padded rows for CDS with no Foldseek hit.
+        write_tbl(
+            per_cds_df,
+            non_cds_dict,
+            list(gb_dict.keys()),
+            prefix,
+            output,
+        )
 
     return sub_dbs_created

--- a/src/phold/subcommands/compare.py
+++ b/src/phold/subcommands/compare.py
@@ -622,8 +622,13 @@ def subcommand_compare(
     filtered_tophits_df = filtered_tophits_df.drop(drop_dupes)
 
     # Two left-joins to merge tophits + weighted bitscores onto per_cds_df.
+    # ``partial`` rides on per_cds_df purely to drive the .tbl writer's
+    # incomplete-end markers (issue #137), so it is dropped here rather than
+    # downstream — merged_df feeds both _per_cds_predictions.tsv and every
+    # sub_db_tophits TSV, and neither should gain a column.
     merged_df = (
         per_cds_df
+        .drop("partial", strict=False)
         .join(filtered_tophits_df,    on="cds_id", how="left")
         .join(weighted_bitscore_df,   on="cds_id", how="left")
     )
@@ -811,12 +816,22 @@ def subcommand_compare(
         # per_cds_df (not merged_df) is the source: write_genbank() already
         # normalised its coordinates, and merged_df's left-joins can introduce
         # null-padded rows for CDS with no Foldseek hit.
+        # Contig lengths let the writer place a minus-strand 5'-partial CDS
+        # against the contig edge (codon_start). Guarded because the proteins
+        # path stores plain dicts here rather than SeqRecords.
+        contig_lengths = {
+            record_id: len(record.seq)
+            for record_id, record in gb_dict.items()
+            if getattr(record, "seq", None) is not None
+        }
+
         write_tbl(
             per_cds_df,
             non_cds_dict,
             list(gb_dict.keys()),
             prefix,
             output,
+            contig_lengths=contig_lengths,
         )
 
     return sub_dbs_created

--- a/tests/unit/test_tbl.py
+++ b/tests/unit/test_tbl.py
@@ -1,0 +1,288 @@
+"""
+Function-level tests for phold.io.tbl — the NCBI feature table writer (issue #137).
+
+The .tbl is a submission format: table2asn parses it positionally, so the
+tests below pin the exact line shape (tab counts, coordinate order, which
+qualifiers are emitted) rather than just "a file was written".
+
+Run::
+
+    pytest tests/unit/test_tbl.py -v
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from Bio.SeqFeature import FeatureLocation, SeqFeature
+
+from phold.io.tbl import write_tbl
+
+
+def _per_cds_df(rows):
+    return pl.DataFrame(
+        rows,
+        schema={
+            "contig_id": pl.Utf8,
+            "cds_id": pl.Utf8,
+            "start": pl.Int64,
+            "end": pl.Int64,
+            "strand": pl.Int64,
+            "product": pl.Utf8,
+            "function": pl.Utf8,
+            "annotation_method": pl.Utf8,
+            "transl_table": pl.Utf8,
+        },
+    )
+
+
+def _cds_row(**kw):
+    row = {
+        "contig_id": "contig1",
+        "cds_id": "contig1_CDS_0001",
+        "start": 100,
+        "end": 400,
+        "strand": 1,
+        "product": "terminase large subunit",
+        "function": "head and packaging",
+        "annotation_method": "foldseek",
+        "transl_table": "11",
+    }
+    row.update(kw)
+    return row
+
+
+def _write(tmp_path, cds_rows, non_cds=None, contig_ids=("contig1",)):
+    out = write_tbl(
+        _per_cds_df(cds_rows),
+        non_cds or {},
+        list(contig_ids),
+        "phold",
+        tmp_path,
+    )
+    return out.read_text()
+
+
+# ─── basic shape ────────────────────────────────────────────────────────────
+
+
+def test_writes_prefixed_filename(tmp_path):
+    write_tbl(_per_cds_df([_cds_row()]), {}, ["contig1"], "myprefix", tmp_path)
+    assert (tmp_path / "myprefix.tbl").exists()
+
+
+def test_cds_block_format(tmp_path):
+    """One CDS -> a >Feature header plus a coordinate line and 4 qualifiers."""
+    text = _write(tmp_path, [_cds_row()])
+
+    assert text == (
+        ">Feature contig1\n"
+        "100\t400\tCDS\n"
+        "\t\t\tproduct\tterminase large subunit\n"
+        "\t\t\tfunction\thead and packaging\n"
+        "\t\t\tinference\tfoldseek\n"
+        "\t\t\ttransl_table\t11\n"
+    )
+
+
+def test_qualifier_lines_have_exactly_three_leading_tabs(tmp_path):
+    """table2asn is positional — the qualifier indent must be 3 tabs, not 2 or 4."""
+    text = _write(tmp_path, [_cds_row()])
+    for line in text.splitlines():
+        if line.startswith("\t"):
+            assert line.startswith("\t\t\t") and not line.startswith("\t\t\t\t")
+
+
+# ─── strand encoding ────────────────────────────────────────────────────────
+
+
+def test_minus_strand_swaps_coordinates(tmp_path):
+    """Strand is encoded by coordinate order — minus strand is written high-first."""
+    text = _write(tmp_path, [_cds_row(strand=-1, start=100, end=400)])
+    assert "400\t100\tCDS\n" in text
+
+
+def test_plus_strand_keeps_coordinate_order(tmp_path):
+    text = _write(tmp_path, [_cds_row(strand=1, start=100, end=400)])
+    assert "100\t400\tCDS\n" in text
+
+
+# ─── null / empty handling ──────────────────────────────────────────────────
+
+
+def test_null_product_is_skipped_not_written_empty(tmp_path):
+    """A bare 'product' line with no value is a table2asn parse error."""
+    text = _write(tmp_path, [_cds_row(product=None)])
+    assert "\t\t\tproduct\n" not in text
+    assert "\t\t\tproduct\t\n" not in text
+    assert "\t\t\tfunction\thead and packaging\n" in text
+
+
+def test_empty_dataframe_still_writes_contig_headers(tmp_path):
+    """Contigs with no features still need a >Feature header for table2asn."""
+    out = write_tbl(
+        pl.DataFrame(schema={"contig_id": pl.Utf8}),
+        {},
+        ["contig1", "contig2"],
+        "phold",
+        tmp_path,
+    )
+    assert out.read_text() == ">Feature contig1\n>Feature contig2\n"
+
+
+# ─── multi-contig ───────────────────────────────────────────────────────────
+
+
+def test_features_are_grouped_under_their_own_contig(tmp_path):
+    text = _write(
+        tmp_path,
+        [
+            _cds_row(contig_id="contig1", start=1, end=99),
+            _cds_row(contig_id="contig2", start=5, end=50),
+        ],
+        contig_ids=("contig1", "contig2"),
+    )
+    c1, c2 = text.split(">Feature contig2\n")
+    assert "1\t99\tCDS\n" in c1
+    assert "5\t50\tCDS\n" in c2
+    assert "1\t99\tCDS\n" not in c2
+
+
+def test_contig_order_follows_supplied_order(tmp_path):
+    text = _write(
+        tmp_path,
+        [_cds_row(contig_id="contig2"), _cds_row(contig_id="contig1")],
+        contig_ids=("contig2", "contig1"),
+    )
+    assert text.index(">Feature contig2") < text.index(">Feature contig1")
+
+
+# ─── non-CDS pass-through (tRNA / CRISPR / tmRNA) ───────────────────────────
+
+
+def _trna_feature():
+    """A tRNA shaped like the ones in tests/test_data/SAOMS1.gbk."""
+    return SeqFeature(
+        FeatureLocation(115193, 115265, strand=-1),
+        type="tRNA",
+        qualifiers={
+            "ID": ["DQEPQRKE_tRNA_0001"],
+            "transl_table": ["11"],
+            "product": ["tRNA-Met(CAT)"],
+            "isotype": ["Met"],
+            "anticodon": ["CAT"],
+            "locus_tag": ["DQEPQRKE_tRNA_0001"],
+            "source": ["tRNAscan-SE_2.0.12"],
+            "score": ["61.2"],
+        },
+    )
+
+
+def test_trna_is_emitted_with_biopython_coordinate_conversion(tmp_path):
+    """BioPython locations are 0-based half-open; the .tbl is 1-based inclusive.
+
+    FeatureLocation(115193, 115265) is bases 115194..115265, and on the minus
+    strand that is written high-coordinate first.
+    """
+    text = _write(tmp_path, [], {"contig1": {"t1": _trna_feature()}})
+    assert "115265\t115194\ttRNA\n" in text
+
+
+def test_trna_qualifiers_filtered_and_ordered(tmp_path):
+    text = _write(tmp_path, [], {"contig1": {"t1": _trna_feature()}})
+
+    assert "\t\t\tproduct\ttRNA-Met(CAT)\n" in text
+    assert "\t\t\tanticodon\tCAT\n" in text
+    # product must precede anticodon per _NON_CDS_QUALIFIER_ORDER
+    assert text.index("product\ttRNA") < text.index("anticodon\tCAT")
+
+
+@pytest.mark.parametrize(
+    "blocked", ["ID", "locus_tag", "score", "source", "isotype", "transl_table"]
+)
+def test_internal_qualifiers_never_reach_the_submission_file(tmp_path, blocked):
+    """Pipeline bookkeeping must not leak into a GenBank submission."""
+    text = _write(tmp_path, [], {"contig1": {"t1": _trna_feature()}})
+    assert f"\t\t\t{blocked}\t" not in text
+
+
+def test_biopython_bare_string_qualifiers_are_handled(tmp_path):
+    """Phold-built features store qualifiers as bare strings, not lists."""
+    feature = SeqFeature(
+        FeatureLocation(0, 60, strand=1),
+        type="tRNA",
+        qualifiers={"product": "tRNA-Phe(GAA)"},
+    )
+    text = _write(tmp_path, [], {"contig1": {"t": feature}})
+    assert "1\t60\ttRNA\n" in text
+    assert "\t\t\tproduct\ttRNA-Phe(GAA)\n" in text
+
+
+def test_pharokka_trna_qualifier_becomes_product(tmp_path):
+    """Pharokka's /trna= is not a valid NCBI qualifier; product is, and is
+    mandatory for tRNA. write_genbank renames it in place, but write_tbl must
+    not depend on that having run first."""
+    feature = SeqFeature(
+        FeatureLocation(0, 72, strand=1),
+        type="tRNA",
+        qualifiers={"trna": ["tRNA-Met(CAT)"], "anticodon": ["CAT"]},
+    )
+    text = _write(tmp_path, [], {"contig1": {"t": feature}})
+
+    assert "\t\t\tproduct\ttRNA-Met(CAT)\n" in text
+    assert "\t\t\ttrna\t" not in text
+
+
+def test_existing_product_wins_over_trna_alias(tmp_path):
+    feature = SeqFeature(
+        FeatureLocation(0, 72, strand=1),
+        type="tRNA",
+        qualifiers={"trna": ["stale"], "product": ["tRNA-Phe(GAA)"]},
+    )
+    text = _write(tmp_path, [], {"contig1": {"t": feature}})
+
+    assert "\t\t\tproduct\ttRNA-Phe(GAA)\n" in text
+    assert "stale" not in text
+
+
+def test_write_tbl_does_not_mutate_input_features(tmp_path):
+    """The caller's SeqFeature dict is shared with the GenBank writer."""
+    feature = SeqFeature(
+        FeatureLocation(0, 72, strand=1),
+        type="tRNA",
+        qualifiers={"trna": ["tRNA-Met(CAT)"]},
+    )
+    _write(tmp_path, [], {"contig1": {"t": feature}})
+
+    assert feature.qualifiers == {"trna": ["tRNA-Met(CAT)"]}
+
+
+def test_crispr_repeat_region_qualifiers(tmp_path):
+    feature = SeqFeature(
+        FeatureLocation(999, 1050, strand=1),
+        type="repeat_region",
+        qualifiers={
+            "rpt_family": ["CRISPR"],
+            "rpt_type": ["direct"],
+            "rpt_unit_seq": ["GTTTC"],
+            "ID": ["crispr_1"],
+        },
+    )
+    text = _write(tmp_path, [], {"contig1": {"c": feature}})
+    assert "1000\t1050\trepeat_region\n" in text
+    assert "\t\t\trpt_family\tCRISPR\n" in text
+    assert "\t\t\trpt_unit_seq\tGTTTC\n" in text
+    assert "\t\t\tID\t" not in text
+
+
+def test_non_cds_features_sorted_by_start(tmp_path):
+    late = SeqFeature(FeatureLocation(500, 560, strand=1), type="tRNA", qualifiers={})
+    early = SeqFeature(FeatureLocation(10, 70, strand=1), type="tRNA", qualifiers={})
+    text = _write(tmp_path, [], {"contig1": {"late": late, "early": early}})
+    assert text.index("11\t70\ttRNA") < text.index("501\t560\ttRNA")
+
+
+def test_cds_and_non_cds_both_present(tmp_path):
+    text = _write(tmp_path, [_cds_row()], {"contig1": {"t1": _trna_feature()}})
+    assert "100\t400\tCDS\n" in text
+    assert "115265\t115194\ttRNA\n" in text
+    assert text.count(">Feature contig1\n") == 1

--- a/tests/unit/test_tbl.py
+++ b/tests/unit/test_tbl.py
@@ -26,11 +26,14 @@ def _per_cds_df(rows):
             "cds_id": pl.Utf8,
             "start": pl.Int64,
             "end": pl.Int64,
-            "strand": pl.Int64,
+            # write_genbank converts strand to "+"/"-" strings before the .tbl
+            # writer ever sees per_cds_df, so the fixture matches that.
+            "strand": pl.Utf8,
             "product": pl.Utf8,
             "function": pl.Utf8,
             "annotation_method": pl.Utf8,
             "transl_table": pl.Utf8,
+            "partial": pl.Utf8,
         },
     )
 
@@ -41,23 +44,31 @@ def _cds_row(**kw):
         "cds_id": "contig1_CDS_0001",
         "start": 100,
         "end": 400,
-        "strand": 1,
+        "strand": "+",
         "product": "terminase large subunit",
         "function": "head and packaging",
         "annotation_method": "foldseek",
         "transl_table": "11",
+        "partial": "00",
     }
     row.update(kw)
     return row
 
 
-def _write(tmp_path, cds_rows, non_cds=None, contig_ids=("contig1",)):
+def _write(
+    tmp_path,
+    cds_rows,
+    non_cds=None,
+    contig_ids=("contig1",),
+    contig_lengths=None,
+):
     out = write_tbl(
         _per_cds_df(cds_rows),
         non_cds or {},
         list(contig_ids),
         "phold",
         tmp_path,
+        contig_lengths=contig_lengths,
     )
     return out.read_text()
 
@@ -95,14 +106,155 @@ def test_qualifier_lines_have_exactly_three_leading_tabs(tmp_path):
 # ─── strand encoding ────────────────────────────────────────────────────────
 
 
-def test_minus_strand_swaps_coordinates(tmp_path):
-    """Strand is encoded by coordinate order — minus strand is written high-first."""
-    text = _write(tmp_path, [_cds_row(strand=-1, start=100, end=400)])
+def test_minus_strand_is_written_high_coordinate_first(tmp_path):
+    """Strand is encoded by coordinate order — minus strand is written high-first.
+
+    per_cds_df is ALREADY in transcription order: write_genbank assigns
+    ``start = location.end`` for a minus-strand CDS, so start > end in the
+    dataframe and the writer must pass the pair straight through. Re-orienting
+    here would write every reverse-strand CDS backwards.
+    """
+    text = _write(tmp_path, [_cds_row(strand="-", start=400, end=100)])
     assert "400\t100\tCDS\n" in text
 
 
 def test_plus_strand_keeps_coordinate_order(tmp_path):
-    text = _write(tmp_path, [_cds_row(strand=1, start=100, end=400)])
+    text = _write(tmp_path, [_cds_row(strand="+", start=100, end=400)])
+    assert "100\t400\tCDS\n" in text
+
+
+# ─── partial CDS (incomplete ends) ──────────────────────────────────────────
+#
+# Prodigal's ``partial`` flag is two digits in *genomic* orientation, left edge
+# then right edge, on both strands. Verified against pyrodigal's own GFF
+# writer: reverse-complementing a sequence turns a left-edge "10" gene into a
+# right-edge "01" gene.
+
+
+def test_complete_cds_has_no_partial_markers(tmp_path):
+    text = _write(tmp_path, [_cds_row(partial="00")])
+    assert "100\t400\tCDS\n" in text
+    assert "<" not in text and ">Feature" in text
+
+
+def test_missing_partial_column_is_treated_as_complete(tmp_path):
+    """Older Pharokka / NCBI / Bakta input carries no partial qualifier."""
+    text = _write(tmp_path, [_cds_row(partial=None)])
+    assert "100\t400\tCDS\n" in text
+    assert "\t\t\tcodon_start\t" not in text
+
+
+def test_plus_strand_five_prime_partial(tmp_path):
+    """+ strand, partial at the genomic left = incomplete 5' end -> '<'."""
+    text = _write(tmp_path, [_cds_row(strand="+", start=1, end=400, partial="10")])
+    assert "<1\t400\tCDS\n" in text
+
+
+def test_plus_strand_three_prime_partial(tmp_path):
+    """+ strand, partial at the genomic right = incomplete 3' end -> '>'."""
+    text = _write(tmp_path, [_cds_row(strand="+", start=100, end=400, partial="01")])
+    assert "100\t>400\tCDS\n" in text
+
+
+def test_minus_strand_five_prime_partial(tmp_path):
+    """- strand: the 5' end is the genomic RIGHT edge, so "01" marks it.
+
+    per_cds_df stores minus-strand CDS as start=high, end=low.
+    """
+    text = _write(
+        tmp_path,
+        [_cds_row(strand="-", start=400, end=100, partial="01")],
+        contig_lengths={"contig1": 400},
+    )
+    # the high coordinate is the 5' end and carries the '<'
+    assert "<400\t100\tCDS\n" in text
+
+
+def test_minus_strand_three_prime_partial(tmp_path):
+    """- strand: the 3' end is the genomic LEFT edge, so "10" marks it."""
+    text = _write(tmp_path, [_cds_row(strand="-", start=400, end=1, partial="10")])
+    assert "400\t>1\tCDS\n" in text
+
+
+def test_both_ends_partial_gets_both_markers(tmp_path):
+    """Pharokka's if/elif chain misses "11" entirely; both ends must be marked."""
+    text = _write(tmp_path, [_cds_row(strand="+", start=1, end=400, partial="11")])
+    assert "<1\t>400\tCDS\n" in text
+
+
+def test_codon_start_when_plus_partial_not_flush_with_contig_start(tmp_path):
+    """A 5'-partial CDS starting at base 2 is extended to <1 with codon_start 2."""
+    text = _write(tmp_path, [_cds_row(strand="+", start=2, end=400, partial="10")])
+    assert "<1\t400\tCDS\n" in text
+    assert "\t\t\tcodon_start\t2\n" in text
+
+
+def test_no_codon_start_when_plus_partial_flush_at_base_one(tmp_path):
+    text = _write(tmp_path, [_cds_row(strand="+", start=1, end=400, partial="10")])
+    assert "\t\t\tcodon_start\t" not in text
+
+
+def test_codon_start_when_minus_partial_not_flush_with_contig_end(tmp_path):
+    """Minus-strand mirror: 5' end at 398 on a 400bp contig -> codon_start 3."""
+    text = _write(
+        tmp_path,
+        [_cds_row(strand="-", start=398, end=100, partial="01")],
+        contig_lengths={"contig1": 400},
+    )
+    assert "<400\t100\tCDS\n" in text
+    assert "\t\t\tcodon_start\t3\n" in text
+
+
+def test_minus_partial_without_contig_length_still_marks_but_omits_codon_start(
+    tmp_path,
+):
+    """contig_lengths is optional — degrade to the '<' marker alone."""
+    text = _write(tmp_path, [_cds_row(strand="-", start=398, end=100, partial="01")])
+    assert "<398\t100\tCDS\n" in text
+    assert "\t\t\tcodon_start\t" not in text
+
+
+def test_minus_and_plus_partials_are_mirror_images(tmp_path):
+    """The same gene reverse-complemented must produce mirrored output.
+
+    A + strand 5'-partial CDS at 2..556 on a 7148bp contig gives "<1 556" with
+    codon_start 2. Its revcomp is a - strand 5'-partial CDS at 7147..6593,
+    which must give "<7148 6593" with the same codon_start.
+    """
+    plus = _write(
+        tmp_path,
+        [_cds_row(strand="+", start=2, end=556, partial="10")],
+        contig_lengths={"contig1": 7148},
+    )
+    minus = _write(
+        tmp_path,
+        [_cds_row(strand="-", start=7147, end=6593, partial="01")],
+        contig_lengths={"contig1": 7148},
+    )
+
+    assert "<1\t556\tCDS\n" in plus
+    assert "<7148\t6593\tCDS\n" in minus
+    assert "\t\t\tcodon_start\t2\n" in plus
+    assert "\t\t\tcodon_start\t2\n" in minus
+
+
+def test_codon_start_over_three_still_writes(tmp_path):
+    """codon_start is a frame offset; >3 is invalid and is warned about, but
+    must not abort at the end of a long run."""
+    text = _write(tmp_path, [_cds_row(strand="+", start=9, end=400, partial="10")])
+    assert "<1\t400\tCDS\n" in text
+    assert "\t\t\tcodon_start\t9\n" in text
+
+
+def test_codon_start_written_after_transl_table(tmp_path):
+    text = _write(tmp_path, [_cds_row(strand="+", start=2, end=400, partial="10")])
+    assert text.index("transl_table") < text.index("codon_start")
+
+
+@pytest.mark.parametrize("bogus", ["", "1", "abc", "123", "0"])
+def test_malformed_partial_is_ignored(tmp_path, bogus):
+    """A junk partial value must not produce junk coordinates."""
+    text = _write(tmp_path, [_cds_row(partial=bogus)])
     assert "100\t400\tCDS\n" in text
 
 

--- a/tests/unit/test_tbl.py
+++ b/tests/unit/test_tbl.py
@@ -34,6 +34,7 @@ def _per_cds_df(rows):
             "annotation_method": pl.Utf8,
             "transl_table": pl.Utf8,
             "partial": pl.Utf8,
+            "phrog": pl.Utf8,
         },
     )
 
@@ -50,6 +51,7 @@ def _cds_row(**kw):
         "annotation_method": "foldseek",
         "transl_table": "11",
         "partial": "00",
+        "phrog": "1215",
     }
     row.update(kw)
     return row
@@ -83,14 +85,14 @@ def test_writes_prefixed_filename(tmp_path):
 
 def test_cds_block_format(tmp_path):
     """One CDS -> a >Feature header plus a coordinate line and 4 qualifiers."""
-    text = _write(tmp_path, [_cds_row()])
+    text = _write(tmp_path, [_cds_row(phrog="1215")])
 
     assert text == (
         ">Feature contig1\n"
         "100\t400\tCDS\n"
         "\t\t\tproduct\tterminase large subunit\n"
         "\t\t\tfunction\thead and packaging\n"
-        "\t\t\tinference\tfoldseek\n"
+        "\t\t\tinference\tprotein motif:PHROG:1215\n"
         "\t\t\ttransl_table\t11\n"
     )
 
@@ -258,6 +260,65 @@ def test_malformed_partial_is_ignored(tmp_path, bogus):
     assert "100\t400\tCDS\n" in text
 
 
+def test_three_prime_partial_extends_to_contig_end(tmp_path):
+    """NCBI wants a 3'-partial feature to reach the sequence edge.
+
+    Gene callers stop at the last whole codon, leaving trailing bases, and
+    table2asn then warns PartialProblemNotSpliceConsensus3Prime.
+    """
+    text = _write(
+        tmp_path,
+        [_cds_row(strand="+", start=6965, end=7147, partial="01")],
+        contig_lengths={"contig1": 7148},
+    )
+    assert "6965\t>7148\tCDS\n" in text
+
+
+def test_three_prime_partial_extends_to_base_one_on_minus_strand(tmp_path):
+    text = _write(
+        tmp_path,
+        [_cds_row(strand="-", start=184, end=2, partial="10")],
+        contig_lengths={"contig1": 7148},
+    )
+    assert "184\t>1\tCDS\n" in text
+
+
+def test_three_prime_partial_without_contig_length_is_left_alone(tmp_path):
+    text = _write(tmp_path, [_cds_row(strand="+", start=100, end=400, partial="01")])
+    assert "100\t>400\tCDS\n" in text
+
+
+# ─── /inference (INSDC controlled vocabulary) ───────────────────────────────
+#
+# table2asn rejects any /inference without a category prefix from the INSDC
+# list, so Phold's raw annotation_method values can never validate on their own.
+
+
+def test_inference_carries_insdc_category_and_phrog(tmp_path):
+    text = _write(tmp_path, [_cds_row(annotation_method="foldseek", phrog="1215")])
+    assert "\t\t\tinference\tprotein motif:PHROG:1215\n" in text
+
+
+def test_inference_omitted_without_a_phrog_to_cite(tmp_path):
+    """No accession to point at, and table2asn flags a bare category too."""
+    text = _write(tmp_path, [_cds_row(annotation_method="foldseek", phrog="No_PHROG")])
+    assert "\t\t\tinference\t" not in text
+    assert "100\t400\tCDS\n" in text
+
+
+def test_inference_omitted_when_nothing_was_annotated(tmp_path):
+    """annotation_method 'none' means no evidence can honestly be cited."""
+    text = _write(tmp_path, [_cds_row(annotation_method="none", phrog="No_PHROG")])
+    assert "\t\t\tinference\t" not in text
+    assert "100\t400\tCDS\n" in text
+
+
+@pytest.mark.parametrize("method", ["foldseek", "pharokka", "card", "vfdb"])
+def test_no_raw_method_name_ever_reaches_the_inference_qualifier(tmp_path, method):
+    text = _write(tmp_path, [_cds_row(annotation_method=method)])
+    assert f"\t\t\tinference\t{method}\n" not in text
+
+
 # ─── null / empty handling ──────────────────────────────────────────────────
 
 
@@ -343,9 +404,8 @@ def test_trna_qualifiers_filtered_and_ordered(tmp_path):
     text = _write(tmp_path, [], {"contig1": {"t1": _trna_feature()}})
 
     assert "\t\t\tproduct\ttRNA-Met(CAT)\n" in text
-    assert "\t\t\tanticodon\tCAT\n" in text
-    # product must precede anticodon per _NON_CDS_QUALIFIER_ORDER
-    assert text.index("product\ttRNA") < text.index("anticodon\tCAT")
+    # a bare 3-letter anticodon is not a valid NCBI location and is dropped
+    assert "\t\t\tanticodon\t" not in text
 
 
 @pytest.mark.parametrize(
@@ -367,6 +427,34 @@ def test_biopython_bare_string_qualifiers_are_handled(tmp_path):
     text = _write(tmp_path, [], {"contig1": {"t": feature}})
     assert "1\t60\ttRNA\n" in text
     assert "\t\t\tproduct\ttRNA-Phe(GAA)\n" in text
+
+
+def test_valid_anticodon_location_is_preserved(tmp_path):
+    """Pharokka >= v1.8.2 writes the proper NCBI location form, which is kept."""
+    feature = SeqFeature(
+        FeatureLocation(115193, 115265, strand=-1),
+        type="tRNA",
+        qualifiers={
+            "product": ["tRNA-Met(CAT)"],
+            "anticodon": ["(pos:115194..115196,aa:Met,seq:cat)"],
+        },
+    )
+    text = _write(tmp_path, [], {"contig1": {"t": feature}})
+    assert "\t\t\tanticodon\t(pos:115194..115196,aa:Met,seq:cat)\n" in text
+
+
+@pytest.mark.parametrize("bare", ["CAT", "GAA", "gtc"])
+def test_bare_anticodon_code_is_dropped(tmp_path, bare):
+    """Pharokka < v1.8.2 wrote a bare 3-letter code, which table2asn rejects."""
+    feature = SeqFeature(
+        FeatureLocation(0, 72, strand=1),
+        type="tRNA",
+        qualifiers={"product": ["tRNA-Met(CAT)"], "anticodon": [bare]},
+    )
+    text = _write(tmp_path, [], {"contig1": {"t": feature}})
+    assert "\t\t\tanticodon\t" not in text
+    # the tRNA itself is still emitted, with its mandatory product
+    assert "\t\t\tproduct\ttRNA-Met(CAT)\n" in text
 
 
 def test_pharokka_trna_qualifier_becomes_product(tmp_path):


### PR DESCRIPTION
Closes #137.

Adds `<prefix>.tbl`, an NCBI feature table, alongside the existing outputs of `phold run` and `phold compare`, so a Phold-reannotated genome can go to `table2asn` without a hand conversion. Modelled on the `.tbl` Pharokka emits (`pharokka.post_processing.create_tbl`) so the two tools stay interchangeable in a submission pipeline.

Not produced for `proteins-predict` / `proteins-compare`, which have no contig coordinates.

## What's in it

- All CDS, plus the tRNA / tmRNA / CRISPR features carried over from the input GenBank. Phold doesn't predict those, but a feature table that omitted them would describe fewer features than the `.gbk` written beside it.
- Incomplete CDS marked with `<` / `>`, with `codon_start` where the reading frame requires it. `partial` is plumbed through from both input routes — newly recorded from `gene.partial_begin/partial_end` on the pyrodigal path, and read from Pharokka's existing `/partial` qualifier on the GenBank path. The column is dropped at the `merged_df` join, so no existing TSV gains a column.
- Contig lengths passed through so a minus-strand 5'-partial CDS can be placed against the contig edge.

## Validated against table2asn

Checked with table2asn 1.28.1179 (bioconda, osx-64). Three problems showed up, all of which would have hit anyone actually submitting:

**`/inference` was rejected on every single CDS.** It was being written as the raw `annotation_method` (`foldseek`, `pharokka`, `none`). INSDC requires a category from a controlled vocabulary, so table2asn returned `Qualifier had bad value` — 246 hard errors on SAOMS1, 15/15 on a pyrodigal run. Pharokka has the same problem, since it writes its GFF Method column here.

Category picked by measurement rather than guesswork:

| `/inference` value | result |
| --- | --- |
| `similar to AA sequence` | `InvalidInferenceValue` warning |
| `similar to AA sequence:PHROG:1215` | warning — "unrecognized database" |
| `protein motif:PHROG:1215` | clean |
| `alignment:Foldseek:1215` | clean |

The `similar to ... sequence` categories are checked against NCBI's recognised-database list, which PHROG isn't on. `protein motif` isn't checked, and is also the honest description: a PHROG is a protein group / profile, and Phold transfers annotation from the group its structure matched. **This is the one judgement call worth your review** — it's a single constant (`_INFERENCE_CATEGORY`) if you'd rather claim something else. CDS with no PHROG to cite get no `/inference` at all, rather than a bare category (itself flagged) or an invented accession.

**`/anticodon` was rejected** for Pharokka < v1.8.2 input, which writes a bare 3-letter code where NCBI wants a location (`(pos:115194..115196,aa:Met)`). `write_genbank` already warns about that input; the qualifier is now dropped with a warning instead of written knowing it's invalid. The valid location form passes through untouched.

**3'-partial CDS warned** `PartialProblemNotSpliceConsensus3Prime`. Gene callers stop at the last whole codon, leaving 1–2 trailing bases; these are now extended to the contig edge, mirroring the 5' `codon_start` handling.

After the fixes the only findings left are the submission metadata table2asn always wants (`NoPubFound`, `NoTaxonID`, `MissingPubRequirement` — supplied by the submitter's `template.sbt` and organism), plus `BadCDScomponentOverlapTRNA` on SAOMS1, which is genuine in that input: CDS_0193 (115129..115329) spans the tRNA at 115194..115265, and Pharokka's `.tbl` would report it identically. **Zero feature or qualifier findings attributable to the writer.**

## Two bugs caught mid-review

Both were in my own first pass, and both surfaced only once I drove the real `write_genbank` instead of a hand-built dataframe:

1. Strand reaches the writer as `"+"`/`"-"` **strings** — `write_genbank` converts before returning `per_cds_df`. `int(strand) == -1` would have raised `ValueError` on every real run, at the final write step.
2. `per_cds_df` is **already in transcription order** for CDS (`start = location.end` for minus strand, so `start > end`). Re-orienting that pair wrote every reverse-strand CDS backwards — no crash, just a silently wrong submission file, 78 of 246 CDS on SAOMS1.

## Departures from Pharokka

- A CDS partial at both ends (`"11"`) gets both markers, instead of falling through Pharokka's `if/elif` chain unmarked.
- An out-of-range `codon_start` warns instead of aborting — this runs at the very end of a long pipeline.

## Testing

57 unit tests in `tests/unit/test_tbl.py` pinning the exact line shape: tab counts, coordinate order on both strands, BioPython half-open → 1-based conversion, all four partial flags plus `"11"`, `codon_start` on each strand, `/inference` and `/anticodon` rules, qualifier filtering and ordering, multi-contig grouping, and that the writer doesn't mutate the SeqFeatures it shares with the GenBank writer. One test asserts a plus-strand partial and its reverse complement produce mirrored output.

Full suite: 85 passed, 18 skipped. Ruff clean on new files; unchanged counts on the files touched.

End-to-end on both input routes: SAOMS1.gbk (246 CDS, 78 reverse strand, 3 tRNAs) and a truncated NC_043029 through pyrodigal-gv in both orientations — zero misoriented coordinate lines, forward/revcomp producing exact mirrors.

`docs/output.md` updated.
