### PR TITLE
Fix crash when --omit_probs is combined with 3Di masking

### DIFF
--- a/src/phold/__init__.py
+++ b/src/phold/__init__.py
@@ -31,7 +31,7 @@ from phold.utils.constants import CNN_DIR, DB_DIR
 from phold.utils.util import (begin_phold, clean_up_temporary_files, end_phold,
                               get_version, print_citation)
 from phold.utils.validation import (check_dependencies, instantiate_dirs,
-                                    validate_input)
+                                    validate_input, validate_mask_options)
 from importlib.resources import files
 
 log_fmt = (
@@ -478,6 +478,9 @@ def run(
     # initial logging etc
     start_time = begin_phold(params, "run")
 
+    # fail fast — before any model is loaded (see validate_mask_options)
+    validate_mask_options(omit_probs, mask_threshold)
+
     # check foldseek is installed
     check_dependencies()
 
@@ -667,6 +670,9 @@ def predict(
 
     # initial logging etc
     start_time = begin_phold(params, "predict")
+
+    # fail fast — before any model is loaded (see validate_mask_options)
+    validate_mask_options(omit_probs, mask_threshold)
 
     # check the database is installed. The 12-state target DB is only needed by
     # `phold compare`, so predict alone does not require it — the model itself
@@ -970,6 +976,9 @@ def proteins_predict(
 
     # initial logging etc
     start_time = begin_phold(params, "proteins-predict")
+
+    # fail fast — before any model is loaded (see validate_mask_options)
+    validate_mask_options(omit_probs, mask_threshold)
 
     # check the database is installed
     database = validate_db(database, DB_DIR, foldseek_gpu=False)

--- a/src/phold/features/predict_3Di.py
+++ b/src/phold/features/predict_3Di.py
@@ -85,14 +85,32 @@ def write_predictions(
     """
     mask_prop = mask_threshold / 100
 
+    # Masking is opt-in. Previously the loop below ran unconditionally and
+    # indexed ``all_prob[0]`` even when masking was disabled (mask_prop == 0
+    # makes the comparison all-False, so it did nothing but still required the
+    # array) and even when ``--omit_probs`` had left ``all_prob`` as None —
+    # crashing with ``TypeError: 'NoneType' object is not subscriptable`` at
+    # write time, after the entire GPU prediction had already completed.
+    apply_masking = mask_prop > 0
+
     with open(out_path, "w+") as out_f:
         for contig_id, contig_dict in predictions.items():
             # drop zero-length predictions (issue #47)
             contig_dict = {k: v for k, v in contig_dict.items() if len(v[0]) > 0}
 
-            # apply masking in-place: pred is np.byte, all_prob shape (1, L)
-            for key, (pred, mean_prob, all_prob) in contig_dict.items():
-                pred[all_prob[0] < mask_prop] = 20  # 'X'
+            if apply_masking:
+                # apply masking in-place: pred is np.byte, all_prob shape (1, L)
+                for key, (pred, mean_prob, all_prob) in contig_dict.items():
+                    if all_prob is None:
+                        # belt-and-braces: the CLI rejects --omit_probs with a
+                        # non-zero --mask_threshold up front, so this only fires
+                        # for library callers of get_embeddings().
+                        logger.warning(
+                            f"No per-residue probabilities for {key} "
+                            "(probabilities were not retained) — skipping 3Di masking."
+                        )
+                        continue
+                    pred[all_prob[0] < mask_prop] = 20  # 'X'
 
             header_fmt = "{}" if proteins_flag else "{}:{}"
 

--- a/src/phold/subcommands/predict.py
+++ b/src/phold/subcommands/predict.py
@@ -349,6 +349,9 @@ def subcommand_predict(
     ## write the AA CDS to file
     ######
 
+    # Warn once, not once per protein — a real run has O(10^5) sequences.
+    warned_missing_probs = False
+
     with open(fasta_aa, "w") as out_f:
         for contig_id, rest in cds_dict.items():
             aa_contig_dict = cds_dict[contig_id]
@@ -364,11 +367,30 @@ def subcommand_predict(
 
                 try:
                     # this will fail if ProstT5 OOM fails (or fails for some other reason)
-                    prot_seq = mask_low_confidence_aa(
-                        prot_seq,
-                        prediction_contig_dict[seq_id][2],
-                        threshold=mask_prop_threshold,
-                    )
+                    all_prob = prediction_contig_dict[seq_id][2]
+
+                    # Masking is opt-in, and it needs the per-residue
+                    # probabilities that --omit_probs discards. Calling
+                    # mask_low_confidence_aa(prot_seq, None, ...) reaches
+                    # ``np.asarray(None, dtype=np.float64)`` — a silent
+                    # array(nan) on numpy 1.x, a TypeError on numpy 2.x that
+                    # the handler below does not catch. The prediction itself
+                    # succeeded in that case, so leave the sequence unmasked
+                    # rather than blanking it to 'X'.
+                    if mask_prop_threshold > 0:
+                        if all_prob is None:
+                            if not warned_missing_probs:
+                                logger.warning(
+                                    "Per-residue ProstT5 probabilities were not retained "
+                                    "— skipping amino acid masking."
+                                )
+                                warned_missing_probs = True
+                        else:
+                            prot_seq = mask_low_confidence_aa(
+                                prot_seq,
+                                all_prob,
+                                threshold=mask_prop_threshold,
+                            )
                 except (KeyError, IndexError):
                     # in that case, just return 'X' aka masked proteins
                     prot_seq = "X" * len(prot_seq)

--- a/src/phold/utils/validation.py
+++ b/src/phold/utils/validation.py
@@ -121,6 +121,34 @@ def instantiate_dirs(output_dir: Union[str, Path], force: bool, restart: bool = 
             Path(output_dir).mkdir(parents=True, exist_ok=True)
 
 
+def validate_mask_options(omit_probs: bool, mask_threshold: float) -> None:
+    """
+    Checks that --omit_probs and --mask_threshold are compatible.
+
+    Masking needs the per-residue ProstT5 probabilities, which ``--omit_probs``
+    discards during inference (``all_prob`` is left as ``None``). Combining the
+    two used to survive the whole prediction and only blow up at write time
+    with ``TypeError: 'NoneType' object is not subscriptable`` — after the full
+    GPU run had completed. This check runs before any model is loaded so the
+    user loses seconds instead of hours.
+
+    Parameters:
+        omit_probs (bool): Value of --omit_probs.
+        mask_threshold (float): Value of --mask_threshold.
+
+    Returns:
+        None
+    """
+    if omit_probs and mask_threshold > 0:
+        logger.error(
+            f"--omit_probs is incompatible with --mask_threshold {mask_threshold}. "
+            "Masking requires the per-residue ProstT5 probabilities that "
+            "--omit_probs discards. Either drop --omit_probs, or re-run with "
+            "--mask_threshold 0 to disable masking."
+        )
+        sys.exit(1)
+
+
 def check_dependencies() -> None:
     """
     Checks the dependencies and versions of non Python programs (i.e. Foldseek)

--- a/tests/unit/test_predict_3di_masking.py
+++ b/tests/unit/test_predict_3di_masking.py
@@ -1,0 +1,167 @@
+"""
+Regression tests for 3Di masking when per-residue probabilities are absent.
+
+``--omit_probs`` leaves ``all_prob`` as ``None`` in the
+``(pred, mean_prob, all_prob)`` tuple. ``write_predictions`` used to index
+``all_prob[0]`` unconditionally — including when masking was disabled
+(``mask_threshold=0``) — so the run died with
+``TypeError: 'NoneType' object is not subscriptable`` at write time, after
+the entire GPU prediction had already completed.
+
+Run::
+
+    pytest tests/unit/test_predict_3di_masking.py -v
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from phold.features.predict_3Di import write_predictions
+from phold.utils.validation import validate_mask_options
+
+
+def _pred(labels):
+    """A prediction array in the np.byte form the CNN head emits."""
+    return np.array(labels, dtype=np.byte)
+
+
+def _read_fasta(path):
+    """Tiny FASTA reader -> {header: sequence}."""
+    records, header = {}, None
+    for line in path.read_text().splitlines():
+        if line.startswith(">"):
+            header = line[1:]
+            records[header] = ""
+        elif header is not None:
+            records[header] += line
+    return records
+
+
+# ─── write_predictions: masking disabled ────────────────────────────────────
+
+
+def test_write_predictions_mask_threshold_zero_with_none_probs(tmp_path):
+    """mask_threshold=0 + all_prob=None — the original crash.
+
+    Masking is off, so the probabilities are never needed and the loop must
+    not be entered at all.
+    """
+    predictions = {"contig1": {"cds1": (_pred([0, 1, 2]), 82.69, None)}}
+    out = tmp_path / "out_3di.fasta"
+
+    write_predictions(predictions, out, proteins_flag=False, mask_threshold=0)
+
+    assert _read_fasta(out) == {"contig1:cds1": "ACD"}
+
+
+def test_write_predictions_mask_threshold_zero_leaves_prediction_untouched(tmp_path):
+    """mask_threshold=0 must not mask, even when probabilities are available.
+
+    ``all_prob[0] < 0`` is all-False, so the old loop was a no-op that still
+    required the array; the output is unchanged but nothing is now indexed.
+    """
+    pred = _pred([0, 1, 2])
+    predictions = {"contig1": {"cds1": (pred, 82.69, np.array([[0.0, 0.0, 0.0]], dtype=np.float32))}}
+    out = tmp_path / "out_3di.fasta"
+
+    write_predictions(predictions, out, proteins_flag=False, mask_threshold=0)
+
+    assert _read_fasta(out) == {"contig1:cds1": "ACD"}
+    assert pred.tolist() == [0, 1, 2]
+
+
+# ─── write_predictions: masking enabled ─────────────────────────────────────
+
+
+def test_write_predictions_masking_skipped_when_probs_missing(tmp_path):
+    """mask_threshold>0 + all_prob=None — skip with a warning, never crash.
+
+    The CLI rejects this combination up front (see
+    ``test_validate_mask_options_*``); this covers library callers of
+    ``get_embeddings``/``write_predictions`` directly.
+    """
+    predictions = {"contig1": {"cds1": (_pred([0, 1, 2]), 82.69, None)}}
+    out = tmp_path / "out_3di.fasta"
+
+    write_predictions(predictions, out, proteins_flag=False, mask_threshold=25)
+
+    assert _read_fasta(out) == {"contig1:cds1": "ACD"}
+
+
+def test_write_predictions_masking_applied(tmp_path):
+    """The masking path itself still works: probs below the threshold -> 'X'."""
+    all_prob = np.array([[0.9, 0.1, 0.5]], dtype=np.float32)
+    predictions = {"contig1": {"cds1": (_pred([0, 1, 2]), 50.0, all_prob)}}
+    out = tmp_path / "out_3di.fasta"
+
+    # threshold 25 -> mask_prop 0.25, so only the 0.1 residue is masked
+    write_predictions(predictions, out, proteins_flag=False, mask_threshold=25)
+
+    assert _read_fasta(out) == {"contig1:cds1": "AXD"}
+
+
+def test_write_predictions_mixed_none_and_present_probs(tmp_path):
+    """One sequence with probs, one without — the second must not poison the first."""
+    predictions = {
+        "contig1": {
+            "with_probs": (_pred([0, 1, 2]), 50.0, np.array([[0.9, 0.1, 0.9]], dtype=np.float32)),
+            "no_probs": (_pred([0, 1, 2]), 50.0, None),
+        }
+    }
+    out = tmp_path / "out_3di.fasta"
+
+    write_predictions(predictions, out, proteins_flag=False, mask_threshold=25)
+
+    assert _read_fasta(out) == {
+        "contig1:with_probs": "AXD",
+        "contig1:no_probs": "ACD",
+    }
+
+
+def test_write_predictions_proteins_flag_headers(tmp_path):
+    """proteins mode: bare seq_id headers, and still no probs required."""
+    predictions = {"proteins": {"prot1": (_pred([0, 1]), 82.69, None)}}
+    out = tmp_path / "out_3di.fasta"
+
+    write_predictions(predictions, out, proteins_flag=True, mask_threshold=0)
+
+    assert _read_fasta(out) == {"prot1": "AC"}
+
+
+def test_write_predictions_drops_zero_length(tmp_path):
+    """Zero-length predictions are still dropped (issue #47) with all_prob=None."""
+    predictions = {
+        "contig1": {
+            "empty": (_pred([]), 0.0, None),
+            "ok": (_pred([0]), 82.69, None),
+        }
+    }
+    out = tmp_path / "out_3di.fasta"
+
+    write_predictions(predictions, out, proteins_flag=False, mask_threshold=0)
+
+    assert _read_fasta(out) == {"contig1:ok": "A"}
+
+
+# ─── validate_mask_options: fail fast at argument-parsing time ──────────────
+
+
+@pytest.mark.parametrize("mask_threshold", [25, 0.1, 100])
+def test_validate_mask_options_rejects_incompatible_combo(mask_threshold):
+    """--omit_probs with masking on must exit before any model is loaded."""
+    with pytest.raises(SystemExit) as exc:
+        validate_mask_options(omit_probs=True, mask_threshold=mask_threshold)
+    assert exc.value.code == 1
+
+
+@pytest.mark.parametrize(
+    "omit_probs, mask_threshold",
+    [
+        (True, 0),    # masking explicitly disabled — the documented workaround
+        (False, 25),  # the default: probs retained, masking on
+        (False, 0),
+    ],
+)
+def test_validate_mask_options_accepts_valid_combos(omit_probs, mask_threshold):
+    validate_mask_options(omit_probs=omit_probs, mask_threshold=mask_threshold)


### PR DESCRIPTION
Fixes the `--omit_probs` crash that threw away 20 minutes of MI250X compute on 161,473 sequences.

## The defect

`--omit_probs` sets `output_probs=False`, which makes the inference engine store `None` in place of the per-residue probability array ([`inference.py:174-178`](https://github.com/gbouras13/phold-lib)). `write_predictions()` then indexed `all_prob[0]` unconditionally and died with

```
TypeError: 'NoneType' object is not subscriptable
```

at write time — **after the entire GPU prediction had already completed**.

The masking loop also ran when masking was disabled: `mask_threshold=0` makes the comparison all-False, so the loop did nothing but still required the array.

Worth noting: `--mask_threshold` defaults to **25** at the CLI (only the function signature defaults to 0), so plain `phold predict --omit_probs` with no `--mask_threshold` at all was also a guaranteed crash — not just the `--mask_threshold 0` invocation from the report.

## The fix

Fail fast, plus defensive guards, since they cover different callers:

- **`validate_mask_options()`** in `phold/utils/validation.py`, called in `run`, `predict` and `proteins-predict` immediately after `begin_phold` — before the database check and before ProstT5 is loaded. Verified end to end: `proteins-predict --omit_probs` now exits in ~1s with a message naming both escape routes, and `--omit_probs --mask_threshold 0` proceeds normally.
- **`write_predictions()`** skips the masking loop entirely when `mask_threshold` is 0, and warns-and-continues rather than crashing when `all_prob is None` (library callers of `get_embeddings` bypass the CLI check).
- **`subcommand_predict()`** gets the same guard on the amino-acid masking path. Passing `None` to `mask_low_confidence_aa` reaches `np.asarray(None, dtype=np.float64)` — a silent `array(nan)` on numpy 1.x, a `TypeError` on numpy 2.x that the `(KeyError, IndexError)` handler doesn't catch. Proteins whose prediction genuinely failed still become `"X" * len` as before; a merely absent `all_prob` leaves the sequence unmasked rather than blanking a good prediction.

## Not affected

`predict_3di_12st.py` hardcodes `output_probs=True` and doesn't pass `mask_threshold`. `write_probs()` only touches `all_probs` when `output_path_all` is non-None, which is itself gated on `output_probs`.

## Testing

`tests/unit/test_predict_3di_masking.py` — 13 tests covering `mask_threshold=0`, `all_prob=None`, the mixed case, proteins-mode headers, the zero-length drop (#47), masking when probabilities are present, and the CLI validator. Reverting only `predict_3Di.py` makes 5 of them fail with the exact `TypeError` from the traceback.

Full unit suite: 95 passed, 18 skipped. Ruff: new file clean, `src/phold/` count unchanged.
